### PR TITLE
Allow name override

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,8 +9,8 @@ targetCompatibility = 1.8
 sourceCompatibility = 1.8
 
 group = 'com.github.chubbard'
-version = '1.0.4'
-//version = '1.0.5-SNAPSHOT'
+//version = '1.0.5'
+version = '1.0.5-SNAPSHOT'
 description = """
 A simplified standalone ETL engine for groovy.  Gratum is groovy + datum.
 """

--- a/src/main/groovy/gratum/etl/Pipeline.groovy
+++ b/src/main/groovy/gratum/etl/Pipeline.groovy
@@ -967,6 +967,18 @@ public class Pipeline {
     }
 
     /**
+     * Passed a closure that is called with this Pipeline.  This enables you to perform operation
+     * on the Pipeline itself without breaking the flow of functional chain.  This does not
+     * add a step to the Pipeline.
+     * @param The Closure
+     * @return this Pipeline
+     */
+    public Pipeline apply(Closure<Void> applyToPipeline) {
+        applyToPipeline.call( this )
+        return this
+    }
+
+    /**
      * Encrypts using PGP a stream on the pipeline and rewrite that stream back to the pipeline.  It looks for
      * a stream on the Pipeline at streamProperty. Further configuration is performed by the provided Closure
      * that is passed a {@link gratum.pgp.PpgContext}.  You are required to setup the identities, secret key collection,

--- a/src/main/groovy/gratum/source/AbstractSource.groovy
+++ b/src/main/groovy/gratum/source/AbstractSource.groovy
@@ -6,10 +6,24 @@ abstract class AbstractSource implements Source {
 
     String name
 
+    /**
+     * This converts the source into a Pipeline to attach steps to.
+     * @return The Pipeline connected to this Source.
+     */
     @Override
     Pipeline into() {
         Pipeline pipeline = new Pipeline( name )
         pipeline.src = this
         return pipeline
+    }
+
+    /**
+     * Overrides the name of the {@see gratum.etl.Pipeline}.
+     * @param name A string with the name of the pipeline to use.
+     * @return this Source
+     */
+    public <T extends AbstractSource> T name(String name) {
+        this.name = name
+        return (T)this
     }
 }

--- a/src/test/groovy/gratum/etl/PipelineTest.groovy
+++ b/src/test/groovy/gratum/etl/PipelineTest.groovy
@@ -908,4 +908,10 @@ class PipelineTest {
         assert stat.stepTimings.containsKey("${stat.name}.after".toString())
         assert stat.stepTimings["${stat.name}.after".toString()] > 0
     }
+
+    @Test
+    void testNameOverride() {
+        LoadStatistic stat = CsvSource.of("src/test/resources/titanic.csv").name("bill_and_ted_do_the_titanic").into().go()
+        assert stat.name == "bill_and_ted_do_the_titanic"
+    }
 }


### PR DESCRIPTION
- Added method to override the name of the Pipeline with Source.name(). 
- bumped version from 1.0.4 -> 1.0.5
- Added Pipeline.apply which allows for direct manipulation of the Pipeline while maintaining functional method flow
